### PR TITLE
fix: xp and drop when npcs are dead

### DIFF
--- a/scene/src/enemies/MonsterMob.ts
+++ b/scene/src/enemies/MonsterMob.ts
@@ -299,6 +299,7 @@ export class MonsterMob extends GenericMonster {
     Animator.playSingleAnimation(this.entity, this.impactClip)
     if (this.health <= 0) {
       this.onDead()
+      pointerEventsSystem.removeOnPointerDown(this.entity)
     }
   }
 
@@ -308,6 +309,7 @@ export class MonsterMob extends GenericMonster {
 
     if (this.health <= 0) {
       this.onDead()
+      pointerEventsSystem.removeOnPointerDown(this.entity)
       return
     }
 
@@ -357,6 +359,7 @@ export class MonsterMob extends GenericMonster {
 
         if (this.health <= 0) {
           this.onDead()
+          pointerEventsSystem.removeOnPointerDown(this.entity)
           return
         }
 

--- a/scene/src/enemies/monster.ts
+++ b/scene/src/enemies/monster.ts
@@ -315,6 +315,7 @@ export class MonsterOligar extends GenericMonster {
     Animator.playSingleAnimation(this.entity, this.impactClip)
     if (this.health <= 0) {
       this.onDead()
+      pointerEventsSystem.removeOnPointerDown(this.entity)
     }
   }
 
@@ -324,6 +325,7 @@ export class MonsterOligar extends GenericMonster {
 
     if (this.health <= 0) {
       this.onDead()
+      pointerEventsSystem.removeOnPointerDown(this.entity)
       return
     }
 

--- a/scene/src/enemies/monsterHealer.ts
+++ b/scene/src/enemies/monsterHealer.ts
@@ -270,6 +270,7 @@ export class MonsterHealer extends GenericMonster {
     Animator.playSingleAnimation(this.entity, this.impactClip)
     if (this.health <= 0) {
       this.onDead()
+      pointerEventsSystem.removeOnPointerDown(this.entity)
     }
   }
 
@@ -279,6 +280,7 @@ export class MonsterHealer extends GenericMonster {
 
     if (this.health <= 0) {
       this.onDead()
+      pointerEventsSystem.removeOnPointerDown(this.entity)
       return
     }
 

--- a/scene/src/enemies/monsterMage.ts
+++ b/scene/src/enemies/monsterMage.ts
@@ -259,6 +259,7 @@ export class MonsterMage extends GenericMonster {
     Animator.playSingleAnimation(this.entity, this.impactClip)
     if (this.health <= 0) {
       this.onDead()
+      pointerEventsSystem.removeOnPointerDown(this.entity)
     }
   }
 
@@ -268,6 +269,7 @@ export class MonsterMage extends GenericMonster {
 
     if (this.health <= 0) {
       this.onDead()
+      pointerEventsSystem.removeOnPointerDown(this.entity)
       return
     }
 

--- a/scene/src/enemies/monsterMeat.ts
+++ b/scene/src/enemies/monsterMeat.ts
@@ -291,6 +291,7 @@ export class MonsterMeat extends GenericMonster {
     Animator.playSingleAnimation(this.entity, this.impactClip)
     if (this.health <= 0) {
       this.onDead()
+      pointerEventsSystem.removeOnPointerDown(this.entity)
     }
   }
 
@@ -300,6 +301,7 @@ export class MonsterMeat extends GenericMonster {
 
     if (this.health <= 0) {
       this.onDead()
+      pointerEventsSystem.removeOnPointerDown(this.entity)
       return
     }
 

--- a/scene/src/enemies/monsterMobAuto.ts
+++ b/scene/src/enemies/monsterMobAuto.ts
@@ -298,6 +298,7 @@ export class MonsterMobAuto extends GenericMonster {
     Animator.playSingleAnimation(this.entity, this.impactClip)
     if (this.health <= 0) {
       this.onDead()
+      pointerEventsSystem.removeOnPointerDown(this.entity)
     }
   }
 
@@ -307,6 +308,7 @@ export class MonsterMobAuto extends GenericMonster {
 
     if (this.health <= 0) {
       this.onDead()
+      pointerEventsSystem.removeOnPointerDown(this.entity)
       return
     }
 

--- a/scene/src/enemies/monsterPoison.ts
+++ b/scene/src/enemies/monsterPoison.ts
@@ -255,6 +255,7 @@ export class MonsterPoison extends GenericMonster {
     Animator.playSingleAnimation(this.entity, this.impactClip)
     if (this.health <= 0) {
       this.onDead()
+      pointerEventsSystem.removeOnPointerDown(this.entity)
     }
   }
 
@@ -264,6 +265,7 @@ export class MonsterPoison extends GenericMonster {
 
     if (this.health <= 0) {
       this.onDead()
+      pointerEventsSystem.removeOnPointerDown(this.entity)
       return
     }
 
@@ -307,6 +309,7 @@ export class MonsterPoison extends GenericMonster {
 
         if (this.health <= 0) {
           this.onDead()
+          pointerEventsSystem.removeOnPointerDown(this.entity)
           return
         }
 


### PR DESCRIPTION
fix the drop xp and items infinite removing the pointer down event when npcs die